### PR TITLE
application.propertiesの可変値をビルド時に置換

### DIFF
--- a/diy-book-shelf-server/pom.xml
+++ b/diy-book-shelf-server/pom.xml
@@ -23,6 +23,11 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <resource.logging.file>${DBS_LOGGING_FILE}</resource.logging.file>
+        <resource.datasource.url>${DBS_DATASOURCE_URL}</resource.datasource.url>
+        <resource.datasource.username>${DBS_DATASOURCE_USERNAME}</resource.datasource.username>
+        <resource.datasource.password>${DBS_DATASOURCE_PASSWORD}</resource.datasource.password>
     </properties>
 
     <dependencies>

--- a/diy-book-shelf-server/src/main/resources/application-dev.properties
+++ b/diy-book-shelf-server/src/main/resources/application-dev.properties
@@ -1,4 +1,0 @@
-spring.datasource.url=jdbc:h2:mem:test
-spring.datasource.driverClassName=org.h2.Driver
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.hibernate.dialect=org.hibernate.dialect.H2Dialect

--- a/diy-book-shelf-server/src/main/resources/application-production.properties
+++ b/diy-book-shelf-server/src/main/resources/application-production.properties
@@ -1,6 +1,0 @@
-spring.datasource.url=${DIY_BOOK_SHELF_DS_URL}
-spring.datasource.username=${DIY_BOOK_SHELF_DS_USER}
-spring.datasource.password=${DIY_BOOK_SHELF_DS_PASS}
-spring.datasource.driverClassName=com.mysql.jdbc.Driver
-spring.jpa.hibernate.ddl-auto=none
-spring.jpa.hibernate.dialect=org.hibernate.dialect.MySQLDialect

--- a/diy-book-shelf-server/src/main/resources/application.properties
+++ b/diy-book-shelf-server/src/main/resources/application.properties
@@ -1,5 +1,3 @@
-spring.profiles.active=dev
-
 server.port=50049
 
 info.name=${project.artifactId}
@@ -7,5 +5,13 @@ info.version=${project.version}
 
 logging.level.root=INFO
 logging.level.me.u6k=DEBUG
+logging.file=${resource.logging.file}
+
+spring.datasource.url=${resource.datasource.url}
+spring.datasource.username=${resource.datasource.username}
+spring.datasource.password=${resource.datasource.password}
+spring.datasource.driverClassName=com.mysql.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 management.context-path=/env

--- a/diy-book-shelf-server/src/test/resources/application-dev.properties
+++ b/diy-book-shelf-server/src/test/resources/application-dev.properties
@@ -1,4 +1,4 @@
 spring.datasource.url=jdbc:h2:mem:test
 spring.datasource.driverClassName=org.h2.Driver
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.hibernate.dialect=org.hibernate.dialect.H2Dialect

--- a/diy-book-shelf-server/src/test/resources/application-staging.properties
+++ b/diy-book-shelf-server/src/test/resources/application-staging.properties
@@ -1,6 +1,6 @@
-spring.datasource.url=jdbc:mysql://localhost/diy_book_shelf_db
-spring.datasource.username=diy_book_shelf_user
-spring.datasource.password=diy_book_shelf_pass
+spring.datasource.url=${resource.datasource.url}
+spring.datasource.username=${resource.datasource.username}
+spring.datasource.password=${resource.datasource.password}
 spring.datasource.driverClassName=com.mysql.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.hibernate.dialect=org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
`application.properties`の可変値を、ビルド時に置換するようにしました。ビルド前に環境変数に値を設定することで、`mvn test`や`mvn package`で置換されることを確認済みです。
