### PR TITLE
極力、実行時設定は環境変数から取得するように修正

### DIFF
--- a/diy-book-shelf-server/pom.xml
+++ b/diy-book-shelf-server/pom.xml
@@ -23,11 +23,6 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-        <resource.logging.file>${DBS_LOGGING_FILE}</resource.logging.file>
-        <resource.datasource.url>${DBS_DATASOURCE_URL}</resource.datasource.url>
-        <resource.datasource.username>${DBS_DATASOURCE_USERNAME}</resource.datasource.username>
-        <resource.datasource.password>${DBS_DATASOURCE_PASSWORD}</resource.datasource.password>
     </properties>
 
     <dependencies>

--- a/diy-book-shelf-server/src/main/resources/application.properties
+++ b/diy-book-shelf-server/src/main/resources/application.properties
@@ -7,11 +7,10 @@ logging.level.root=INFO
 logging.level.me.u6k=DEBUG
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type=TRACE
-logging.file=${resource.logging.file}
 
-spring.datasource.url=${resource.datasource.url}
-spring.datasource.username=${resource.datasource.username}
-spring.datasource.password=${resource.datasource.password}
+spring.datasource.url=${DBS_DATASOURCE_URL}
+spring.datasource.username=${DBS_DATASOURCE_USERNAME}
+spring.datasource.password=${DBS_DATASOURCE_PASSWORD}
 spring.datasource.driverClassName=com.mysql.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.hibernate.dialect=org.hibernate.dialect.MySQLDialect

--- a/diy-book-shelf-server/src/test/resources/application-staging.properties
+++ b/diy-book-shelf-server/src/test/resources/application-staging.properties
@@ -1,6 +1,6 @@
-spring.datasource.url=${resource.datasource.url}
-spring.datasource.username=${resource.datasource.username}
-spring.datasource.password=${resource.datasource.password}
+spring.datasource.url=${DBS_DATASOURCE_URL}
+spring.datasource.username=${DBS_DATASOURCE_USERNAME}
+spring.datasource.password=${DBS_DATASOURCE_PASSWORD}
 spring.datasource.driverClassName=com.mysql.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.hibernate.dialect=org.hibernate.dialect.MySQLDialect

--- a/doc/environment.md
+++ b/doc/environment.md
@@ -1,0 +1,78 @@
+# 環境定義
+
+## ディレクトリ、ファイル定義
+
+* `/mnt/data/opt/diy-book-shelf/bin/diy-book-shelf-server-*.*.*.jar`
+    * アプリケーション実行ファイルの実体。
+* `/mnt/data/opt/diy-book-shelf/bin/diy-book-shelf-server.conf`
+    * アプリケーション外部設定ファイル。サービス起動時に読み込まれる。環境変数を定義する。
+* `/mnt/data/opt/diy-book-shelf/git/`
+    * gitリポジトリ。ここからソースコードを取得してビルドを行う。
+* `/mnt/data/var/log/diy-book-shelf/*.log`
+    * ログ・ファイル。
+
+## データベース定義
+
+* ミドルウェア
+    * PostgreSQL
+    * OSパッケージ管理システムでインストールする。
+* データベース名(JDBC接続文字列)
+    * 本番: `jdbc:postgresql://localhost:5432/diy_book_shelf_db?charSet=UTF8`
+    * ステージング: `jdbc:postgresql://localhost:5432/diy_book_shelf_stg_db?charSet=UTF8`
+* ユーザー名、パスワード
+    * LastPassを参照
+
+## 環境変数(実行時)
+
+* `DBS_DATASOURCE_URL`: JDBC接続文字列。
+* `DBS_DATASOURCE_USERNAME`: データベース・ユーザー。
+* `DBS_DATASOURCE_PASSWORD`: データベース・パスワード。
+* `LOG_FOLDER`: ログ出力先フォルダー。
+
+## OSユーザー
+
+* diy-book-shelf用のOSユーザーを作成する。
+
+> *TODO:* とりあえずrootで運用する。
+
+## 初回構築手順
+
+### 各種ディレクトリを作成
+
+```
+sudo mkdir /mnt/data/opt/diy-book-shelf/
+sudo mkdir /mnt/data/opt/diy-book-shelf/bin/
+sudo mkdir /mnt/data/var/log/diy-book-shelf/
+```
+
+### git clone
+
+```
+cd /mnt/data/opt/diy-book-shelf/
+git clone git@github.com:u6k/diy-book-shelf.git git
+```
+
+### PostgreSQL構築
+
+PostgreSQLはパッケージャーでインストールする。rootでログインして、以下のコマンドを実行する。`diy_book_shelf_user`、`diy_book_shelf_pass`は、本番用の値に読み替える。
+
+```
+create user diy_book_shelf_user with password 'diy_book_shelf_pass';
+create database diy_book_shelf_db owner diy_book_shelf_user encoding 'UTF8';
+```
+
+同様に、ステージング用にも構築する。
+
+### サービス登録
+
+```
+sudo ln -sf /mnt/data/opt/diy-book-shelf/bin/diy-book-shelf-server-*.*.*.jar /etc/init.d/diy-book-shelf-server
+sudo chkconfig --add diy-book-shelf-server
+```
+
+設定ファイルをコピーして、内容を変更する。
+
+```
+cp /mnt/data/opt/diy-book-shelf/git/diy-book-shelf-server/src/release/conf/diy-book-shelf-server.conf /mnt/data/opt/diy-book-shelf/bin/
+vim /mnt/data/opt/diy-book-shelf/bin/diy-book-shelf-server.conf
+```

--- a/doc/release.md
+++ b/doc/release.md
@@ -1,0 +1,43 @@
+# テスト、ビルド、リリース、実行手順
+
+## ソースコードを最新化
+
+ソースコードを最新化する。同時に、ゴミファイルを削除する。
+
+```
+cd /mnt/data/opt/diy-book-shelf/git/
+git clean -x -d -f
+git reset --hard HEAD
+git fetch
+git pull origin master
+cd diy-book-shelf-server/
+```
+
+## ステージング・テスト
+
+テストを実行する。`-Dspring.datasource.url`、`-Dspring.datasource.username`、`-Dspring.datasource.password`には、ステージング環境の値を設定する。
+
+```
+mvn test package -Dspring.profiles.active=staging -Dspring.datasource.url=xxx -Dspring.datasource.username=xxx -Dspring.datasource.password=xxx
+```
+
+### ビルド
+
+ビルドを実行する。
+
+```
+mvn package -Dmaven.test.skip=true
+cp target/diy-book-shelf-server-*.*.*.jar ../../bin/
+```
+
+### リリース
+
+```
+sudo ln -sf ../../bin/diy-book-shelf-server.*.*.*.jar /etc/init.d/diy-book-shelf-server
+```
+
+### 実行手順
+
+```
+sudo service diy-book-shelf-server restart
+```


### PR DESCRIPTION
ビルド時に実行時設定を決定してしまう手順になっているので、リリース時に設定ファイルや環境変数を整備するようにします。

[55. Installing Spring Boot applications](http://docs.spring.io/spring-boot/docs/1.3.1.RELEASE/reference/htmlsingle/#deployment-install)によれば、Linuxサービス実行の場合は`.conf`スクリプトを起動時に実行するので、その時に環境変数を設定するようにします。
